### PR TITLE
Extend scope for `inputPath` input type

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,26 +2,26 @@ Package: kflow
 Title: Functions for Interacting with Kubeflow from R
 Version: 0.1.0
 Authors@R: 
-    person(given = "Nick",
-           family = "DiQuattro",
-           role = c("aut", "cre"),
-           email = "ndiquattro@gmail.com")
-Description: Convenience functions for writing R code that works in a Kubeflow environment.
+    person("Nick", "DiQuattro", , "ndiquattro@gmail.com", role = c("aut", "cre"))
+Description: Convenience functions for writing R code that works in a
+    Kubeflow environment.
 License: MIT + file LICENSE
-Encoding: UTF-8
-LazyData: true
 URL: https://github.com/ndiquattro/kflow
 BugReports: https://github.com/ndiquattro/kflow/issues
-Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2
 Imports: 
+    dplyr,
     fs,
-    readr,
     jsonlite,
     magrittr,
-    methods,
-    stringr,
     purrr,
+    readr,
+    rlang,
+    stringr,
+    tibble,
     yaml
 Suggests: 
     testthat (>= 2.1.0)
+Encoding: UTF-8
+LazyData: true
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.2.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,10 @@ Imports:
     stringr,
     yaml
 Suggests: 
-    testthat (>= 2.1.0)
+    devtools,
+    testthat (>= 2.1.0),
+    usethis,
+    withr
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,6 @@ License: MIT + file LICENSE
 URL: https://github.com/ndiquattro/kflow
 BugReports: https://github.com/ndiquattro/kflow/issues
 Imports: 
-    dplyr,
     fs,
     jsonlite,
     magrittr,
@@ -17,7 +16,6 @@ Imports:
     readr,
     rlang,
     stringr,
-    tibble,
     yaml
 Suggests: 
     testthat (>= 2.1.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,10 @@
 Package: kflow
 Title: Functions for Interacting with Kubeflow from R
-Version: 0.1.0
-Authors@R: 
-    person("Nick", "DiQuattro", , "ndiquattro@gmail.com", role = c("aut", "cre"))
+Version: 0.1.0.9000
+Authors@R: c(
+    person("Nick", "DiQuattro", , "ndiquattro@gmail.com", role = c("aut", "cre")),
+    person("Michał", "Kamiński", role = "ctb")
+  )
 Description: Convenience functions for writing R code that works in a
     Kubeflow environment.
 License: MIT + file LICENSE

--- a/R/kf_make_component.R
+++ b/R/kf_make_component.R
@@ -9,14 +9,14 @@
 #' input String. Output paths are identified by ending in `_out`. Supported
 #' translations are:
 #'
-#' Inputs (inputValue)
+#' Inputs (inputValue type)
 #' * `_string` = String
 #' * `_int` = Integer
 #' * `_bool` = Bool
 #' * `_float` = Float
 #' * #TODO add support for List and Dict
 #'
-#' Inputs (inputPath)
+#' Inputs (inputPath type) - useful for passing data between components
 #' * `_path` = String
 #'
 #' Outputs

--- a/R/utils.R
+++ b/R/utils.R
@@ -3,6 +3,7 @@ find_kf_type <- function(x) {
 
   lookup <- list(
     string = "String",
+    stringPath = "String",
     int = "Integer",
     float = "Float",
     bool = "Bool",
@@ -14,7 +15,29 @@ find_kf_type <- function(x) {
 }
 
 find_arg_type <- function(x) {
-  x <- stringr::str_extract(x, "[^_]+$")
+  x <- stringr::str_extract(x, "[^_]+$") |>
+    tibble::as_tibble()
 
-  ifelse(x %in% c("string", "int", "float", "bool"), "inputValue", "outputPath")
+  x |>
+    dplyr::mutate(
+      arg_type = dplyr::case_when(
+        value %in% c("string", "int", "float", "bool") ~ "inputValue",
+        value == "stringPath" ~ "inputPath",
+        TRUE ~ "outputPath"
+      )
+    ) |>
+    dplyr::pull(arg_type)
+}
+
+find_arg_defaults <- function(x) {
+  if (is.symbol(x)) {
+    rlang::as_string(x)
+  } else {
+    x
+  }
+
+}
+
+is_arg_optional <- function(x) {
+  ifelse(is.null(x), "yes", "no")
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,9 +1,26 @@
+name_fixer <- function(x) {
+  x_stub <- stringr::str_extract(x, "[^_]+$")
+  # When argument ends in "_metrics":
+  if (x_stub == "metrics") {
+    return("mlpipeline_metrics")
+  }
+
+  # When argument ends in "_uimeta":
+  if (x_stub == "uimeta") {
+    return("mlpipeline_ui_metadata")
+  }
+
+  x
+}
+
 find_kf_type <- function(x) {
+  stopifnot(length(x) == 1)
+
   x <- stringr::str_extract(x, "[^_]+$")
 
   lookup <- list(
     string = "String",
-    stringPath = "String",
+    path = "String",
     int = "Integer",
     float = "Float",
     bool = "Bool",
@@ -15,29 +32,64 @@ find_kf_type <- function(x) {
 }
 
 find_arg_type <- function(x) {
-  x <- stringr::str_extract(x, "[^_]+$") |>
-    tibble::as_tibble()
+  x <- stringr::str_extract(x, "[^_]+$")
 
-  x |>
-    dplyr::mutate(
-      arg_type = dplyr::case_when(
-        value %in% c("string", "int", "float", "bool") ~ "inputValue",
-        value == "stringPath" ~ "inputPath",
-        TRUE ~ "outputPath"
-      )
-    ) |>
-    dplyr::pull(arg_type)
+  if (x %in% c("string", "int", "float", "bool")) {
+    return("inputValue")
+  } else if (x == "path") {
+    return("inputPath")
+  } else if (x %in% c("out", "metrics", "uimeta")) {
+    return("outputPath")
+  } else {
+    stop("Unknown argument type")
+  }
 }
 
-find_arg_defaults <- function(x) {
-  if (is.symbol(x)) {
-    rlang::as_string(x)
-  } else {
-    x
+find_arg_defaults <- function(arg_name, arg_value) {
+  # if default argument is function of some sort change it to character
+  if (is.symbol(arg_value)) {
+
+    if (rlang::as_string(arg_value) == "") {
+      return(as.null(arg_value))
+
+    } else {
+      return(arg_value)
+    }
+
+  } else if (is.numeric(arg_value) & !grepl(x = arg_name, pattern = "_bool$")) {
+
+    arg_value <- fix_int_args(arg_name, arg_value)
+
+  } else if (grepl(x = arg_name, pattern = "_bool$")) {
+
+    arg_value <- fix_bool_args(arg_value)
   }
 
+  return(arg_value)
+}
+
+fix_bool_args <- function(arg_value) {
+  x <- as.logical(arg_value)
+
+  if (length(x) == 0 || is.na(x)) {
+    y <- as.null(x)
+    return(y)
+  }
+
+  class(x) <- "verbatim"
+  return(x)
+}
+
+fix_int_args <- function(arg_name, arg_value) {
+  if (grepl(x = arg_name, pattern = "_int$")) {
+    return(as.integer(arg_value))
+  } else {
+    return(arg_value)
+  }
 }
 
 is_arg_optional <- function(x) {
-  ifelse(is.null(x), "yes", "no")
+  x <- ifelse(is.null(x), TRUE, FALSE)
+  class(x) <- "verbatim"
+  return(x)
 }

--- a/man/kf_make_component.Rd
+++ b/man/kf_make_component.Rd
@@ -31,7 +31,7 @@ determine the type. For example, \code{table_name_string} would be considered an
 input String. Output paths are identified by ending in \verb{_out}. Supported
 translations are:
 
-Inputs (inputValue)
+Inputs (inputValue type)
 \itemize{
 \item \verb{_string} = String
 \item \verb{_int} = Integer
@@ -40,7 +40,7 @@ Inputs (inputValue)
 \item #TODO add support for List and Dict
 }
 
-Inputs (inputPath)
+Inputs (inputPath type) - useful for passing data between components
 \itemize{
 \item \verb{_path} = String
 }

--- a/man/kf_make_component.Rd
+++ b/man/kf_make_component.Rd
@@ -37,6 +37,7 @@ Inputs
 \item \verb{_int} = Integer
 \item \verb{_bool} = Bool
 \item \verb{_float} = Float
+\item #TODO add support for List and Dict
 }
 
 Outputs

--- a/man/kf_make_component.Rd
+++ b/man/kf_make_component.Rd
@@ -31,13 +31,18 @@ determine the type. For example, \code{table_name_string} would be considered an
 input String. Output paths are identified by ending in \verb{_out}. Supported
 translations are:
 
-Inputs
+Inputs (inputValue)
 \itemize{
 \item \verb{_string} = String
 \item \verb{_int} = Integer
 \item \verb{_bool} = Bool
 \item \verb{_float} = Float
 \item #TODO add support for List and Dict
+}
+
+Inputs (inputPath)
+\itemize{
+\item \verb{_path} = String
 }
 
 Outputs

--- a/man/kf_write_output.Rd
+++ b/man/kf_write_output.Rd
@@ -18,7 +18,7 @@ outfile
 Writes content to a Kubeflow provided path for output.
 }
 \details{
-Defaults to \code{\link[readr:write_file]{readr::write_file()}}, but uses \code{\link[jsonlite:write_json]{jsonlite::write_json()}} or \code{\link[readr:write_csv]{readr::write_csv()}} for appropriate classes.
+Defaults to \code{\link[readr:read_file]{readr::write_file()}}, but uses \code{\link[jsonlite:read_json]{jsonlite::write_json()}} or \code{\link[readr:write_delim]{readr::write_csv()}} for appropriate classes.
 }
 \examples{
 predictions_table_name <- "model_predictions"

--- a/man/kflow-package.Rd
+++ b/man/kflow-package.Rd
@@ -19,5 +19,10 @@ Useful links:
 \author{
 \strong{Maintainer}: Nick DiQuattro \email{ndiquattro@gmail.com}
 
+Other contributors:
+\itemize{
+  \item Michał Kamiński [contributor]
+}
+
 }
 \keyword{internal}

--- a/tests/testthat/files/test_functions.R
+++ b/tests/testthat/files/test_functions.R
@@ -1,0 +1,43 @@
+comp_fun1 <- function(location_string,
+                      location2_path,
+                      count_int,
+                      weight_float,
+                      flag_bool,
+                      path_metrics,
+                      path_uimeta,
+                      results_out) {
+  2 * 2
+}
+
+comp_fun2 <- function(location_string,
+                      default_location_string = "/home/user",
+                      optional_location_string = NULL) {
+  2 * 2
+}
+
+comp_fun3 <- function(my_int,
+                      default_my_int = 1,
+                      optional_my_int = NULL,
+                      default_not_my_int = 1.5) {
+  2 * 2
+}
+
+comp_fun4 <- function(my_float,
+                      default_my_float = 1.5,
+                      optional_my_float = NULL,
+                      default_not_my_float = 1L) {
+  2 * 2
+}
+
+comp_fun5 <- function(my_bool,
+                      default_my_bool = TRUE,
+                      optional_my_bool = NULL,
+                      default_not_my_bool = "some text") {
+  2 * 2
+}
+
+comp_fun6 <- function(my_out,
+                      my_metrics,
+                      my_uimeta) {
+  2 * 2
+}

--- a/tests/testthat/test-find_arg_type.R
+++ b/tests/testthat/test-find_arg_type.R
@@ -1,0 +1,20 @@
+test_that("correctly identifies inputValues", {
+  expect_true(find_arg_type("my_string") == "inputValue")
+  expect_true(find_arg_type("my_int") == "inputValue")
+  expect_true(find_arg_type("my_float") == "inputValue")
+  expect_true(find_arg_type("my_bool") == "inputValue")
+})
+
+test_that("correctly identifies inputPath", {
+  expect_true(find_arg_type("my_path") == "inputPath")
+})
+
+test_that("correctly identifies outputPath", {
+  expect_true(find_arg_type("my_out") == "outputPath")
+  expect_true(find_arg_type("my_metrics") == "outputPath")
+  expect_true(find_arg_type("my_uimeta") == "outputPath")
+})
+
+test_that("error on unknown arg_type", {
+  expect_error(find_arg_type("my_random_type"), "Unknown argument type")
+})

--- a/tests/testthat/test-find_kf_type.R
+++ b/tests/testthat/test-find_kf_type.R
@@ -1,0 +1,62 @@
+test_that("correctly finds strings", {
+  got <- find_kf_type("my_string")
+  want <- "String"
+
+  expect_equal(got, want)
+})
+
+test_that("correctly finds paths as strings", {
+  got <- find_kf_type("my_path")
+  want <- "String"
+
+  expect_equal(got, want)
+})
+
+test_that("correctly finds int", {
+  got <- find_kf_type("my_int")
+  want <- "Integer"
+
+  expect_equal(got, want)
+})
+
+test_that("correctly finds floats", {
+  got <- find_kf_type("my_float")
+  want <- "Float"
+
+  expect_equal(got, want)
+})
+
+test_that("correctly finds bools", {
+  got <- find_kf_type("my_bool")
+  want <- "Bool"
+
+  expect_equal(got, want)
+})
+
+test_that("correctly finds metrics", {
+  got <- find_kf_type("my_metrics")
+  want <- "Metrics"
+
+  expect_equal(got, want)
+})
+
+test_that("correctly finds UI metadata", {
+  got <- find_kf_type("my_uimeta")
+  want <- "UI_metadata"
+
+  expect_equal(got, want)
+})
+
+test_that("ignores '_out'", {
+  got <- find_kf_type("my_out")
+  want <- NULL
+
+  expect_equal(got, want)
+})
+
+test_that("ignores all other suffixes", {
+  got <- find_kf_type("my_random_suffix")
+  want <- NULL
+
+  expect_equal(got, want)
+})

--- a/tests/testthat/test-fix_args.R
+++ b/tests/testthat/test-fix_args.R
@@ -1,0 +1,30 @@
+test_that("works for logicals", {
+  got <- fix_bool_args(TRUE)
+  want <- TRUE
+  class(want) <- "verbatim"
+
+  expect_equal(got, want)
+})
+
+test_that("works for integers", {
+  got <- fix_bool_args(1)
+  want <- TRUE
+  class(want) <- "verbatim"
+
+  expect_equal(got, want)
+})
+
+test_that("TRUE for any number that is not 0/1 - default R behaviour", {
+  got <- fix_bool_args(1.5)
+  want <- TRUE
+  class(want) <- "verbatim"
+
+  expect_equal(got, want)
+})
+
+test_that("NULL for text", {
+  got <- fix_bool_args("text")
+  want <- NULL
+
+  expect_equal(got, want)
+})

--- a/tests/testthat/test-kf_add_metric.R
+++ b/tests/testthat/test-kf_add_metric.R
@@ -1,15 +1,29 @@
 test_metrics <- kf_init_metrics()
 
 test_that("Input validation works", {
-  expect_error(kf_add_metric(test_metrics, "ROC"), "Name does not match required pattern.")
-  expect_error(kf_add_metric(test_metrics, name = "roc", value = "15"), "Value must be numeric.")
-  expect_error(kf_add_metric(test_metrics, name = "roc", value = .15, format = "plain"), "Format must be either RAW or PERCENTAGE.")
+  expect_error(kf_add_metric(test_metrics, "ROC"),
+               "Name does not match required pattern.")
+  expect_error(kf_add_metric(test_metrics, name = "roc", value = "15"),
+               "Value must be numeric.")
+  expect_error(
+    kf_add_metric(
+      test_metrics,
+      name = "roc",
+      value = .15,
+      format = "plain"
+    ),
+    "Format must be either RAW or PERCENTAGE."
+  )
 })
 
 test_that("Single metric is added correctly", {
   one_added <- kf_add_metric(test_metrics, "roc", .5, "RAW")
 
-  expect_output(print(one_added, pretty = FALSE), '{"metrics":[{"name":"roc","numberValue":0.5,"format":"RAW"}]}', fixed = TRUE)
+  expect_output(
+    print(one_added, pretty = FALSE),
+    '{"metrics":[{"name":"roc","numberValue":0.5,"format":"RAW"}]}',
+    fixed = TRUE
+  )
 })
 
 test_that("Multiple metrics are added correctly", {
@@ -18,5 +32,9 @@ test_that("Multiple metrics are added correctly", {
     kf_add_metric("roc", .5, "RAW") %>%
     kf_add_metric("accuracy", .5, "PERCENTAGE")
 
-  expect_output(print(two_added, pretty = FALSE), '{"metrics":[{"name":"roc","numberValue":0.5,"format":"RAW"},{"name":"accuracy","numberValue":0.5,"format":"PERCENTAGE"}]}', fixed = TRUE)
+  expect_output(
+    print(two_added, pretty = FALSE),
+    '{"metrics":[{"name":"roc","numberValue":0.5,"format":"RAW"},{"name":"accuracy","numberValue":0.5,"format":"PERCENTAGE"}]}',
+    fixed = TRUE
+  )
 })

--- a/tests/testthat/test-kf_add_roc.R
+++ b/tests/testthat/test-kf_add_roc.R
@@ -4,7 +4,11 @@ mock_loc <- "gs://project/rocfile.csv"
 test_that("Single roc is added correctly", {
   one_added <- kf_add_roc(test_ui, mock_loc)
 
-  expect_output(print(one_added, pretty = FALSE), '{"outputs":[{"type":"roc","format":"csv","schema":[{"name":"thresholds","type":"NUMBER"},{"name":"fpr","type":"NUMBER"},{"name":"tpr","type":"NUMBER"}],"source":"gs://project/rocfile.csv"}]}', fixed = TRUE)
+  expect_output(
+    print(one_added, pretty = FALSE),
+    '{"outputs":[{"type":"roc","format":"csv","schema":[{"name":"thresholds","type":"NUMBER"},{"name":"fpr","type":"NUMBER"},{"name":"tpr","type":"NUMBER"}],"source":"gs://project/rocfile.csv"}]}',
+    fixed = TRUE
+  )
 })
 
 test_that("Multiple rocs are added correctly", {
@@ -13,5 +17,9 @@ test_that("Multiple rocs are added correctly", {
     kf_add_roc(mock_loc) %>%
     kf_add_roc(mock_loc)
 
-  expect_output(print(two_added, pretty = FALSE), '{"outputs":[{"type":"roc","format":"csv","schema":[{"name":"thresholds","type":"NUMBER"},{"name":"fpr","type":"NUMBER"},{"name":"tpr","type":"NUMBER"}],"source":"gs://project/rocfile.csv"},{"type":"roc","format":"csv","schema":[{"name":"thresholds","type":"NUMBER"},{"name":"fpr","type":"NUMBER"},{"name":"tpr","type":"NUMBER"}],"source":"gs://project/rocfile.csv"}]}', fixed = TRUE)
+  expect_output(
+    print(two_added, pretty = FALSE),
+    '{"outputs":[{"type":"roc","format":"csv","schema":[{"name":"thresholds","type":"NUMBER"},{"name":"fpr","type":"NUMBER"},{"name":"tpr","type":"NUMBER"}],"source":"gs://project/rocfile.csv"},{"type":"roc","format":"csv","schema":[{"name":"thresholds","type":"NUMBER"},{"name":"fpr","type":"NUMBER"},{"name":"tpr","type":"NUMBER"}],"source":"gs://project/rocfile.csv"}]}',
+    fixed = TRUE
+  )
 })

--- a/tests/testthat/test-kf_init_metrics.R
+++ b/tests/testthat/test-kf_init_metrics.R
@@ -9,6 +9,14 @@ test_that("Custom class is applied correctly", {
 
 test_that("Print methods respond correctly", {
 
-  expect_output(print(test_mets, pretty = FALSE), '{"metrics":[]}', fixed = TRUE)
-  expect_output(print(test_mets, preview = FALSE), "$metrics\nlist()", fixed = TRUE)
+  expect_output(
+    print(test_mets, pretty = FALSE),
+    '{"metrics":[]}',
+    fixed = TRUE
+    )
+  expect_output(
+    print(test_mets, preview = FALSE),
+    "$metrics\nlist()",
+    fixed = TRUE
+    )
 })

--- a/tests/testthat/test-kf_make_component.R
+++ b/tests/testthat/test-kf_make_component.R
@@ -1,13 +1,421 @@
-comp_fun <- function(location_string, count_int, weight_float, flag_bool, path_metrics,
-                     path_metaui, results_out) {
-  2 * 2
-}
+source(testthat::test_path("files", "test_functions.R"))
 
 test_that("File is written", {
+
   tfile <- tempfile()
 
-  kf_make_component("mean", "Test Function", "A function for testing",
-                    "docker/docker", file = tfile)
+  kf_make_component(
+    rfunction = "comp_fun1",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
 
   expect_true(file.exists(tfile))
+})
+
+##### TEST STRING INPUTS -------------------------------------------------------
+
+test_that("'_string' is parsed correctly", {
+
+  tfile <- tempfile()
+
+  kf_make_component(
+    rfunction = "comp_fun2",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
+
+  expect_true(file.exists(tfile))
+
+  got <- yaml::read_yaml(tfile)
+
+  expect_true(got$inputs[[1]]$name == "location_string")
+  expect_true(got$inputs[[1]]$type == "String")
+  expect_true(is.null(got$inputs[[1]]$default))
+  expect_false(got$inputs[[1]]$optional)
+  expect_true(got$implementation$container$args[[1]]$inputValue == "location_string")
+})
+
+test_that("'_string' with default value is parsed correctly", {
+
+  tfile <- tempfile()
+
+  kf_make_component(
+    rfunction = "comp_fun2",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
+
+  expect_true(file.exists(tfile))
+
+  got <- yaml::read_yaml(tfile)
+
+  expect_true(got$inputs[[2]]$name == "default_location_string")
+  expect_true(got$inputs[[2]]$type == "String")
+  expect_true(got$inputs[[2]]$default == "/home/user")
+  expect_false(got$inputs[[2]]$optional)
+  expect_true(got$implementation$container$args[[2]]$inputValue == "default_location_string")
+})
+
+test_that("optional '_string' is parsed correctly", {
+
+  tfile <- tempfile()
+
+  kf_make_component(
+    rfunction = "comp_fun2",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
+
+  expect_true(file.exists(tfile))
+
+  got <- yaml::read_yaml(tfile)
+
+  expect_true(got$inputs[[3]]$name == "optional_location_string")
+  expect_true(got$inputs[[3]]$type == "String")
+  expect_true(is.null(got$inputs[[3]]$default))
+  expect_true(got$inputs[[3]]$optional)
+  expect_true(got$implementation$container$args[[3]]$inputValue == "optional_location_string")
+})
+
+##### TEST INTEGER INPUTS ------------------------------------------------------
+
+test_that("'_int' is parsed correctly", {
+
+  tfile <- tempfile()
+
+  kf_make_component(
+    rfunction = "comp_fun3",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
+
+  expect_true(file.exists(tfile))
+
+  got <- yaml::read_yaml(tfile)
+
+  expect_true(got$inputs[[1]]$name == "my_int")
+  expect_true(got$inputs[[1]]$type == "Integer")
+  expect_true(is.null(got$inputs[[1]]$default))
+  expect_false(got$inputs[[1]]$optional)
+  expect_true(got$implementation$container$args[[1]]$inputValue == "my_int")
+})
+
+test_that("'_int' with default value is parsed correctly", {
+
+  tfile <- tempfile()
+
+  kf_make_component(
+    rfunction = "comp_fun3",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
+
+  expect_true(file.exists(tfile))
+
+  got <- yaml::read_yaml(tfile)
+
+  expect_true(got$inputs[[2]]$name == "default_my_int")
+  expect_true(got$inputs[[2]]$type == "Integer")
+  expect_true(got$inputs[[2]]$default == 1L)
+  expect_false(got$inputs[[2]]$optional)
+  expect_true(got$implementation$container$args[[2]]$inputValue == "default_my_int")
+})
+
+test_that("optional '_int' is parsed correctly", {
+
+  tfile <- tempfile()
+
+  kf_make_component(
+    rfunction = "comp_fun3",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
+
+  expect_true(file.exists(tfile))
+
+  got <- yaml::read_yaml(tfile)
+
+  expect_true(got$inputs[[3]]$name == "optional_my_int")
+  expect_true(got$inputs[[3]]$type == "Integer")
+  expect_true(is.null(got$inputs[[3]]$default))
+  expect_true(got$inputs[[3]]$optional)
+  expect_true(got$implementation$container$args[[3]]$inputValue == "optional_my_int")
+})
+
+test_that("default '_int' is parsed to integer even if provided as double", {
+
+  tfile <- tempfile()
+
+  kf_make_component(
+    rfunction = "comp_fun3",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
+
+  expect_true(file.exists(tfile))
+
+  got <- yaml::read_yaml(tfile)
+
+  expect_true(got$inputs[[4]]$name == "default_not_my_int")
+  expect_true(got$inputs[[4]]$type == "Integer")
+  expect_true(got$inputs[[4]]$default == 1L)
+  expect_false(got$inputs[[4]]$optional)
+  expect_true(got$implementation$container$args[[4]]$inputValue == "default_not_my_int")
+})
+
+##### TEST FLOATING INPUTS -----------------------------------------------------
+
+test_that("'_float' is parsed correctly", {
+
+  tfile <- tempfile()
+
+  kf_make_component(
+    rfunction = "comp_fun4",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
+
+  expect_true(file.exists(tfile))
+
+  got <- yaml::read_yaml(tfile)
+
+  expect_true(got$inputs[[1]]$name == "my_float")
+  expect_true(got$inputs[[1]]$type == "Float")
+  expect_true(is.null(got$inputs[[1]]$default))
+  expect_false(got$inputs[[1]]$optional)
+  expect_true(got$implementation$container$args[[1]]$inputValue == "my_float")
+})
+
+test_that("'_float' with default value is parsed correctly", {
+
+  tfile <- tempfile()
+
+  kf_make_component(
+    rfunction = "comp_fun4",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
+
+  expect_true(file.exists(tfile))
+
+  got <- yaml::read_yaml(tfile)
+
+  expect_true(got$inputs[[2]]$name == "default_my_float")
+  expect_true(got$inputs[[2]]$type == "Float")
+  expect_true(got$inputs[[2]]$default == 1.5)
+  expect_false(got$inputs[[2]]$optional)
+  expect_true(got$implementation$container$args[[2]]$inputValue == "default_my_float")
+})
+
+test_that("optional '_float' is parsed correctly", {
+
+  tfile <- tempfile()
+
+  kf_make_component(
+    rfunction = "comp_fun4",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
+
+  expect_true(file.exists(tfile))
+
+  got <- yaml::read_yaml(tfile)
+
+  expect_true(got$inputs[[3]]$name == "optional_my_float")
+  expect_true(got$inputs[[3]]$type == "Float")
+  expect_true(is.null(got$inputs[[3]]$default))
+  expect_true(got$inputs[[3]]$optional)
+  expect_true(got$implementation$container$args[[3]]$inputValue == "optional_my_float")
+})
+
+test_that("default '_float' is parsed to double even if provided as integer", {
+
+  tfile <- tempfile()
+
+  kf_make_component(
+    rfunction = "comp_fun4",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
+
+  expect_true(file.exists(tfile))
+
+  got <- yaml::read_yaml(tfile)
+
+  expect_true(got$inputs[[4]]$name == "default_not_my_float")
+  expect_true(got$inputs[[4]]$type == "Float")
+  expect_true(got$inputs[[4]]$default == as.double(1))
+  expect_false(got$inputs[[4]]$optional)
+  expect_true(got$implementation$container$args[[4]]$inputValue == "default_not_my_float")
+})
+
+##### TEST BOOLEAN INPUTS ------------------------------------------------------
+
+test_that("'_bool' is parsed correctly", {
+
+  tfile <- tempfile()
+
+  kf_make_component(
+    rfunction = "comp_fun5",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
+
+  expect_true(file.exists(tfile))
+
+  got <- yaml::read_yaml(tfile)
+
+  expect_true(got$inputs[[1]]$name == "my_bool")
+  expect_true(got$inputs[[1]]$type == "Bool")
+  expect_true(is.null(got$inputs[[1]]$default))
+  expect_false(got$inputs[[1]]$optional)
+  expect_true(got$implementation$container$args[[1]]$inputValue == "my_bool")
+})
+
+test_that("'_bool' with default value is parsed correctly", {
+
+  tfile <- tempfile()
+
+  kf_make_component(
+    rfunction = "comp_fun5",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
+
+  expect_true(file.exists(tfile))
+
+  got <- yaml::read_yaml(tfile)
+
+  expect_true(got$inputs[[2]]$name == "default_my_bool")
+  expect_true(got$inputs[[2]]$type == "Bool")
+  expect_true(got$inputs[[2]]$default == TRUE)
+  expect_false(got$inputs[[2]]$optional)
+  expect_true(got$implementation$container$args[[2]]$inputValue == "default_my_bool")
+})
+
+test_that("optional '_bool' is parsed correctly", {
+
+  tfile <- tempfile()
+
+  kf_make_component(
+    rfunction = "comp_fun5",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
+
+  expect_true(file.exists(tfile))
+
+  got <- yaml::read_yaml(tfile)
+
+  expect_true(got$inputs[[3]]$name == "optional_my_bool")
+  expect_true(got$inputs[[3]]$type == "Bool")
+  expect_true(is.null(got$inputs[[3]]$default))
+  expect_true(got$inputs[[3]]$optional)
+  expect_true(got$implementation$container$args[[3]]$inputValue == "optional_my_bool")
+})
+
+test_that("default '_bool' converts to NULL if default is not logical or 0/1", {
+
+  tfile <- tempfile()
+
+  kf_make_component(
+    rfunction = "comp_fun5",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
+
+  expect_true(file.exists(tfile))
+
+  got <- yaml::read_yaml(tfile)
+
+  expect_true(got$inputs[[4]]$name == "default_not_my_bool")
+  expect_true(got$inputs[[4]]$type == "Bool")
+  expect_true(is.null(got$inputs[[4]]$default))
+  expect_false(got$inputs[[4]]$optional)
+  expect_true(got$implementation$container$args[[4]]$inputValue == "default_not_my_bool")
+})
+
+##### TEST REGULAR OUTPUTS -----------------------------------------------------
+
+test_that("'_out' is parsed correctly", {
+
+  tfile <- tempfile()
+
+  kf_make_component(
+    rfunction = "comp_fun6",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
+
+  expect_true(file.exists(tfile))
+
+  got <- yaml::read_yaml(tfile)
+
+  expect_true(got$outputs[[1]]$name == "my_out")
+  expect_true(is.null(got$outputs[[1]]$type))
+  expect_true(got$implementation$container$args[[1]]$outputPath == "my_out")
+})
+
+##### TEST METRICS OUTPUTS -----------------------------------------------------
+
+test_that("'_out' is parsed correctly", {
+
+  tfile <- tempfile()
+
+  kf_make_component(
+    rfunction = "comp_fun6",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
+
+  expect_true(file.exists(tfile))
+
+  got <- yaml::read_yaml(tfile)
+
+  print(got)
+  expect_true(got$outputs[[2]]$name == "mlpipeline_metrics")
+  expect_true(got$outputs[[2]]$type == "Metrics")
+  expect_true(got$implementation$container$args[[2]]$outputPath == "mlpipeline_metrics")
+})
+
+##### TEST UI METADATA OUTPUTS -------------------------------------------------
+
+test_that("'_out' is parsed correctly", {
+
+  tfile <- tempfile()
+
+  kf_make_component(
+    rfunction = "comp_fun6",
+    name = "Test Function",
+    description = "A function for testing",
+    image = "docker/docker",
+    file = tfile)
+
+  expect_true(file.exists(tfile))
+
+  got <- yaml::read_yaml(tfile)
+
+  print(got)
+  expect_true(got$outputs[[3]]$name == "mlpipeline_ui_metadata")
+  expect_true(got$outputs[[3]]$type == "UI_metadata")
+  expect_true(got$implementation$container$args[[3]]$outputPath == "mlpipeline_ui_metadata")
 })

--- a/tests/testthat/test-kf_make_component.R
+++ b/tests/testthat/test-kf_make_component.R
@@ -2,66 +2,33 @@ source(testthat::test_path("files", "test_functions.R"))
 
 test_that("File is written", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun1",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
+  expect_true(file.exists(tmp_file))
 })
 
-test_that("file is written when function comes from loaded package", {
 
-  tmp_dir <- tempdir()
-  withr::defer(fs::dir_delete(tmp_dir))
-
-  usethis::ui_silence(usethis::create_package(tmp_dir, open = FALSE))
-
-  withr::with_dir(
-    tmp_dir,
-    {
-
-      fun <- c("comp_fun1 <- function(location_string,location2_path,count_int,",
-               "weight_float,flag_bool,path_metrics,path_uimeta,results_out) {",
-               "2 * 2}")
-
-      writeLines(fun, con = "R/foo.R", sep = "\n")
-
-      devtools::load_all()
-      kf_make_component(
-        rfunction = "comp_fun1",
-        name = "Test Function",
-        description = "A function for testing",
-        image = "docker/docker",
-        file = "component.yaml"
-      )
-
-      expect_true(fs::file_exists("component.yaml"))
-    })
-
-
-})
-
-##### TEST STRING INPUTS -------------------------------------------------------
+# ##### TEST STRING INPUTS -------------------------------------------------------
 
 test_that("'_string' is parsed correctly", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun2",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
-
-  got <- yaml::read_yaml(tfile)
+  got <- yaml::read_yaml(tmp_file)
 
   expect_true(got$inputs[[1]]$name == "location_string")
   expect_true(got$inputs[[1]]$type == "String")
@@ -72,18 +39,16 @@ test_that("'_string' is parsed correctly", {
 
 test_that("'_string' with default value is parsed correctly", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun2",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
-
-  got <- yaml::read_yaml(tfile)
+  got <- yaml::read_yaml(tmp_file)
 
   expect_true(got$inputs[[2]]$name == "default_location_string")
   expect_true(got$inputs[[2]]$type == "String")
@@ -94,18 +59,16 @@ test_that("'_string' with default value is parsed correctly", {
 
 test_that("optional '_string' is parsed correctly", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun2",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
-
-  got <- yaml::read_yaml(tfile)
+  got <- yaml::read_yaml(tmp_file)
 
   expect_true(got$inputs[[3]]$name == "optional_location_string")
   expect_true(got$inputs[[3]]$type == "String")
@@ -114,22 +77,20 @@ test_that("optional '_string' is parsed correctly", {
   expect_true(got$implementation$container$args[[3]]$inputValue == "optional_location_string")
 })
 
-##### TEST INTEGER INPUTS ------------------------------------------------------
+# ##### TEST INTEGER INPUTS ------------------------------------------------------
 
 test_that("'_int' is parsed correctly", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun3",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
-
-  got <- yaml::read_yaml(tfile)
+  got <- yaml::read_yaml(tmp_file)
 
   expect_true(got$inputs[[1]]$name == "my_int")
   expect_true(got$inputs[[1]]$type == "Integer")
@@ -140,18 +101,16 @@ test_that("'_int' is parsed correctly", {
 
 test_that("'_int' with default value is parsed correctly", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun3",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
-
-  got <- yaml::read_yaml(tfile)
+  got <- yaml::read_yaml(tmp_file)
 
   expect_true(got$inputs[[2]]$name == "default_my_int")
   expect_true(got$inputs[[2]]$type == "Integer")
@@ -162,18 +121,16 @@ test_that("'_int' with default value is parsed correctly", {
 
 test_that("optional '_int' is parsed correctly", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun3",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
-
-  got <- yaml::read_yaml(tfile)
+  got <- yaml::read_yaml(tmp_file)
 
   expect_true(got$inputs[[3]]$name == "optional_my_int")
   expect_true(got$inputs[[3]]$type == "Integer")
@@ -184,18 +141,16 @@ test_that("optional '_int' is parsed correctly", {
 
 test_that("default '_int' is parsed to integer even if provided as double", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun3",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
-
-  got <- yaml::read_yaml(tfile)
+  got <- yaml::read_yaml(tmp_file)
 
   expect_true(got$inputs[[4]]$name == "default_not_my_int")
   expect_true(got$inputs[[4]]$type == "Integer")
@@ -204,22 +159,20 @@ test_that("default '_int' is parsed to integer even if provided as double", {
   expect_true(got$implementation$container$args[[4]]$inputValue == "default_not_my_int")
 })
 
-##### TEST FLOATING INPUTS -----------------------------------------------------
+# ##### TEST FLOATING INPUTS -----------------------------------------------------
 
 test_that("'_float' is parsed correctly", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun4",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
-
-  got <- yaml::read_yaml(tfile)
+  got <- yaml::read_yaml(tmp_file)
 
   expect_true(got$inputs[[1]]$name == "my_float")
   expect_true(got$inputs[[1]]$type == "Float")
@@ -230,18 +183,16 @@ test_that("'_float' is parsed correctly", {
 
 test_that("'_float' with default value is parsed correctly", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun4",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
-
-  got <- yaml::read_yaml(tfile)
+  got <- yaml::read_yaml(tmp_file)
 
   expect_true(got$inputs[[2]]$name == "default_my_float")
   expect_true(got$inputs[[2]]$type == "Float")
@@ -252,18 +203,16 @@ test_that("'_float' with default value is parsed correctly", {
 
 test_that("optional '_float' is parsed correctly", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun4",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
-
-  got <- yaml::read_yaml(tfile)
+  got <- yaml::read_yaml(tmp_file)
 
   expect_true(got$inputs[[3]]$name == "optional_my_float")
   expect_true(got$inputs[[3]]$type == "Float")
@@ -274,18 +223,16 @@ test_that("optional '_float' is parsed correctly", {
 
 test_that("default '_float' is parsed to double even if provided as integer", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun4",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
-
-  got <- yaml::read_yaml(tfile)
+  got <- yaml::read_yaml(tmp_file)
 
   expect_true(got$inputs[[4]]$name == "default_not_my_float")
   expect_true(got$inputs[[4]]$type == "Float")
@@ -294,22 +241,20 @@ test_that("default '_float' is parsed to double even if provided as integer", {
   expect_true(got$implementation$container$args[[4]]$inputValue == "default_not_my_float")
 })
 
-##### TEST BOOLEAN INPUTS ------------------------------------------------------
+# ##### TEST BOOLEAN INPUTS ------------------------------------------------------
 
 test_that("'_bool' is parsed correctly", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun5",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
-
-  got <- yaml::read_yaml(tfile)
+  got <- yaml::read_yaml(tmp_file)
 
   expect_true(got$inputs[[1]]$name == "my_bool")
   expect_true(got$inputs[[1]]$type == "Bool")
@@ -320,18 +265,16 @@ test_that("'_bool' is parsed correctly", {
 
 test_that("'_bool' with default value is parsed correctly", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun5",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
-
-  got <- yaml::read_yaml(tfile)
+  got <- yaml::read_yaml(tmp_file)
 
   expect_true(got$inputs[[2]]$name == "default_my_bool")
   expect_true(got$inputs[[2]]$type == "Bool")
@@ -342,18 +285,16 @@ test_that("'_bool' with default value is parsed correctly", {
 
 test_that("optional '_bool' is parsed correctly", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun5",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
-
-  got <- yaml::read_yaml(tfile)
+  got <- yaml::read_yaml(tmp_file)
 
   expect_true(got$inputs[[3]]$name == "optional_my_bool")
   expect_true(got$inputs[[3]]$type == "Bool")
@@ -364,18 +305,16 @@ test_that("optional '_bool' is parsed correctly", {
 
 test_that("default '_bool' converts to NULL if default is not logical or 0/1", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun5",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
-
-  got <- yaml::read_yaml(tfile)
+  got <- yaml::read_yaml(tmp_file)
 
   expect_true(got$inputs[[4]]$name == "default_not_my_bool")
   expect_true(got$inputs[[4]]$type == "Bool")
@@ -384,69 +323,61 @@ test_that("default '_bool' converts to NULL if default is not logical or 0/1", {
   expect_true(got$implementation$container$args[[4]]$inputValue == "default_not_my_bool")
 })
 
-##### TEST REGULAR OUTPUTS -----------------------------------------------------
+# ##### TEST REGULAR OUTPUTS -----------------------------------------------------
 
 test_that("'_out' is parsed correctly", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun6",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
-
-  got <- yaml::read_yaml(tfile)
+  got <- yaml::read_yaml(tmp_file)
 
   expect_true(got$outputs[[1]]$name == "my_out")
   expect_true(is.null(got$outputs[[1]]$type))
   expect_true(got$implementation$container$args[[1]]$outputPath == "my_out")
 })
 
-##### TEST METRICS OUTPUTS -----------------------------------------------------
+# ##### TEST METRICS OUTPUTS -----------------------------------------------------
 
 test_that("'_out' is parsed correctly", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun6",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
+  got <- yaml::read_yaml(tmp_file)
 
-  got <- yaml::read_yaml(tfile)
-
-  print(got)
   expect_true(got$outputs[[2]]$name == "mlpipeline_metrics")
   expect_true(got$outputs[[2]]$type == "Metrics")
   expect_true(got$implementation$container$args[[2]]$outputPath == "mlpipeline_metrics")
 })
 
-##### TEST UI METADATA OUTPUTS -------------------------------------------------
+# ##### TEST UI METADATA OUTPUTS -------------------------------------------------
 
 test_that("'_out' is parsed correctly", {
 
-  tfile <- tempfile()
+  tmp_file <- tempfile()
 
   kf_make_component(
     rfunction = "comp_fun6",
     name = "Test Function",
     description = "A function for testing",
     image = "docker/docker",
-    file = tfile)
+    file = tmp_file)
 
-  expect_true(file.exists(tfile))
+  got <- yaml::read_yaml(tmp_file)
 
-  got <- yaml::read_yaml(tfile)
-
-  print(got)
   expect_true(got$outputs[[3]]$name == "mlpipeline_ui_metadata")
   expect_true(got$outputs[[3]]$type == "UI_metadata")
   expect_true(got$implementation$container$args[[3]]$outputPath == "mlpipeline_ui_metadata")

--- a/tests/testthat/test-kf_make_component.R
+++ b/tests/testthat/test-kf_make_component.R
@@ -14,6 +14,38 @@ test_that("File is written", {
   expect_true(file.exists(tfile))
 })
 
+test_that("file is written when function comes from loaded package", {
+
+  tmp_dir <- tempdir()
+  withr::defer(fs::dir_delete(tmp_dir))
+
+  usethis::ui_silence(usethis::create_package(tmp_dir, open = FALSE))
+
+  withr::with_dir(
+    tmp_dir,
+    {
+
+      fun <- c("comp_fun1 <- function(location_string,location2_path,count_int,",
+               "weight_float,flag_bool,path_metrics,path_uimeta,results_out) {",
+               "2 * 2}")
+
+      writeLines(fun, con = "R/foo.R", sep = "\n")
+
+      devtools::load_all()
+      kf_make_component(
+        rfunction = "comp_fun1",
+        name = "Test Function",
+        description = "A function for testing",
+        image = "docker/docker",
+        file = "component.yaml"
+      )
+
+      expect_true(fs::file_exists("component.yaml"))
+    })
+
+
+})
+
 ##### TEST STRING INPUTS -------------------------------------------------------
 
 test_that("'_string' is parsed correctly", {


### PR DESCRIPTION
- Kubeflow component accepts also `inputPath`, not only `inputValue`. Therefore `_path` slug was added to accepted function argument names.
- added unit tests